### PR TITLE
Updated readme to point to the most helpful wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ The app is available via the BSD license.  Contributions welcome. Contact labs a
 
 Version History: https://github.com/ForceDotComLabs/Milestones-PM/wiki/Version-History
 
+Getting Started
+----
+For a page that outlines how to perform a basic setup of the package and start creating a demo project, see the [User Guide](https://github.com/ForceDotComLabs/Milestones-PM/wiki/DOC:-Milestones-PM-User-Guide).
+
+
 Meta
 ----
 Milestones PM was originally designed by Reid Carlberg.
@@ -23,7 +28,7 @@ Contributors include:
 
 
 
-Get to know Milestones PM. https://github.com/ForceDotComLabs/Milestones-PM/wiki/HOW-TO-Get-to-Know-Milestones-PM
+Get to know Milestones PM. https://github.com/ForceDotComLabs/Milestones-PM/wiki/
 
 
 


### PR DESCRIPTION
The previous version of the front page required hunting around to find the right wiki page for the user guide.  I called out the correct User Guide page with a "Getting Started" section.

I also edited the link in the Meta section.  It seemed to point to a page that was just a handful of IDE and object mapping tips, so I updated the URL to drop the visitor onto the top level wiki page.  I'll propose some additional wiki cleanups in future commits.